### PR TITLE
Update to Godot 4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,15 @@ Implements a VMC receiver in Godot
 
 ## Build
 
+First initialize submodules, specifically the 4.0 branch of `godot-cpp`:
 ```bash
 git submodule update --init --recursive
+cd third_party/godot-cpp
+git pull https://github.com/godotengine/godot-cpp 4.0
+cd ../..
+```
+Then build GodotVMCLib using CMake:
+```bash
 mkdir build
 cd build
 cmake ..
@@ -15,5 +22,5 @@ cmake --install .
 
 ## Using GodotVMCLib in a project
 
-To use GodotVMCLib in a godot project, add the repository under `addons/godot-vmc-lib` in the project folder. An example project can be found under: https://github.com/DigitOtter/godot-vmc
+To use GodotVMCLib in a Godot project, add the repository under `addons/godot-vmc-lib` in the project folder and build it. An example project can be found under: https://github.com/DigitOtter/godot-vmc
 

--- a/godot_vmc_lib/vmc_godot.cpp
+++ b/godot_vmc_lib/vmc_godot.cpp
@@ -2,6 +2,10 @@
 
 #include "vmc_receiver.h"
 
+#include <gdextension_interface.h>
+#include <godot_cpp/core/defs.hpp>
+#include <godot_cpp/core/class_db.hpp>
+#include <godot_cpp/godot.hpp>
 
 using namespace godot;
 
@@ -19,7 +23,8 @@ void uninitialize_vmc_godot(ModuleInitializationLevel p_level)
 		return;
 }
 
-extern "C" GDNativeBool GDN_EXPORT vmc_godot_library_init(const GDNativeInterface *p_interface, const GDNativeExtensionClassLibraryPtr p_library, GDNativeInitialization *r_initialization)
+extern "C" {
+GDExtensionBool GDE_EXPORT vmc_godot_library_init(const GDExtensionInterface *p_interface, const GDExtensionClassLibraryPtr p_library, GDExtensionInitialization *r_initialization)
 {
 	godot::GDExtensionBinding::InitObject init_obj(p_interface, p_library, r_initialization);
 
@@ -28,4 +33,5 @@ extern "C" GDNativeBool GDN_EXPORT vmc_godot_library_init(const GDNativeInterfac
 	init_obj.set_minimum_library_initialization_level(MODULE_INITIALIZATION_LEVEL_SCENE);
 
 	return init_obj.init();
+}
 }


### PR DESCRIPTION
This completes the move to GDExtension and updates the build instructions to build specifically for Godot 4.0. I've tested it and it works (at least on my machine).